### PR TITLE
Fix settings.yaml markup

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -18,7 +18,7 @@ fields:
     width: 50
   link_id:
     type: toggle
-    width:50
+    width: 50
   user_tracking_options_section:
     type: section
   track_uid:


### PR DESCRIPTION
When using the stricter YAML parser this line breaks the addon.